### PR TITLE
Add minimal AI chat widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Care-Mate Chat Widget
+
+This repository provides a minimal AI chat widget backed by a Netlify serverless function using OpenAI's API. The widget can be embedded into any webpage, including Webflow sites.
+
+## Structure
+```
+chat-app/
+  ├── netlify/functions/chat.js  # serverless function
+  ├── client/
+  │   ├── index.html              # demo page / embed target
+  │   ├── chat.js                 # frontend logic
+  │   └── styles.css              # basic styles
+  └── package.json
+```
+
+## Deploying to Netlify
+1. Create a new Netlify site and link it to this repository.
+2. Set the **Publish directory** to `chat-app/client`.
+3. Ensure the environment variable `OPENAI_API_KEY` is configured in Netlify.
+4. After deploying, your chat function will be available at `https://<your-site>.netlify.app/.netlify/functions/chat`.
+
+## Embedding in Webflow
+Include the following snippet in an Embed element and adjust the `src` URL to your deployed Netlify site:
+
+```html
+<iframe src="https://<your-site>.netlify.app/index.html" style="border:none;width:100%;height:400px;"></iframe>
+```
+
+The iframe will render the chat UI contained in `client/index.html`.

--- a/chat-app/client/chat.js
+++ b/chat-app/client/chat.js
@@ -1,0 +1,32 @@
+const messagesEl = document.getElementById('messages');
+const form = document.getElementById('chat-form');
+const input = document.getElementById('chat-input');
+
+function addMessage(content, from) {
+  const div = document.createElement('div');
+  div.className = from;
+  div.textContent = content;
+  messagesEl.appendChild(div);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  addMessage(text, 'user');
+  input.value = '';
+
+  const resp = await fetch('/.netlify/functions/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: 'demo-user', message: text })
+  });
+
+  if (resp.ok) {
+    const data = await resp.json();
+    addMessage(data.reply, 'ai');
+  } else {
+    addMessage('Error contacting AI', 'ai');
+  }
+});

--- a/chat-app/client/index.html
+++ b/chat-app/client/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Care-Mate Chat</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="chat-container">
+    <div id="messages"></div>
+    <form id="chat-form">
+      <input type="text" id="chat-input" placeholder="Type your message" autocomplete="off" required />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+  <script src="chat.js" type="module"></script>
+</body>
+</html>

--- a/chat-app/client/styles.css
+++ b/chat-app/client/styles.css
@@ -1,0 +1,19 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 10px;
+}
+#chat-container {
+  max-width: 400px;
+  margin: 0 auto;
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+#messages {
+  height: 300px;
+  overflow-y: auto;
+  border: 1px solid #eee;
+  margin-bottom: 10px;
+  padding: 5px;
+}
+.user { color: blue; }
+.ai { color: green; }

--- a/chat-app/netlify/functions/chat.js
+++ b/chat-app/netlify/functions/chat.js
@@ -1,0 +1,26 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export const handler = async (event, context) => {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: JSON.stringify({ error: 'Method Not Allowed' }) };
+    }
+    const { userId, message } = JSON.parse(event.body || '{}');
+    if (!message || message.trim() === '') {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Empty message' }) };
+    }
+
+    const aiResponse = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: message }]
+    });
+
+    const reply = aiResponse.choices?.[0]?.message?.content || 'Sorry, I didn\u2019t catch that.';
+    return { statusCode: 200, body: JSON.stringify({ reply }) };
+  } catch (err) {
+    console.error('Chat function error:', err);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal Server Error' }) };
+  }
+};

--- a/chat-app/package.json
+++ b/chat-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "care-mate-chat",
+  "version": "1.0.0",
+  "main": "netlify/functions/chat.js",
+  "type": "module",
+  "dependencies": {
+    "openai": "^4.0.0",
+    "node-fetch": "^3.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- implement Netlify serverless `chat.js` calling OpenAI
- add simple chat UI (HTML/CSS/JS)
- document deployment and Webflow embedding instructions

## Testing
- `node -e "import('./chat-app/netlify/functions/chat.js').then(m=>console.log(typeof m.handler))"` (fails due to missing OPENAI_API_KEY as expected)


------
https://chatgpt.com/codex/tasks/task_e_683fcdcfe78883339460bdd64f1b001b