### PR TITLE
Revamp chat widget design

### DIFF
--- a/chat-widget/index.html
+++ b/chat-widget/index.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Care-Mate Chat Widget</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
-  <body class="bg-gray-900">
+  <body class="bg-gray-900 font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/chat-widget/src/App.tsx
+++ b/chat-widget/src/App.tsx
@@ -1,15 +1,28 @@
 import ChatWidget from './components/ChatWidget';
 import { motion, useScroll, useTransform } from 'framer-motion';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import './index.css';
 
 export default function App() {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end end'] });
   const y = useTransform(scrollYProgress, [0, 1], [0, -100]);
+  const [darkMode, setDarkMode] = useState(true);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-gradient-start to-primary-gradient-end">
+    <div
+      className="relative min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-primary-gradient-start to-primary-gradient-end dark:from-dark-gradient-start dark:to-dark-gradient-end"
+    >
+      <button
+        onClick={() => setDarkMode((d) => !d)}
+        className="absolute top-4 right-4 px-3 py-1 rounded-md text-sm backdrop-blur-md bg-white/20 text-white hover:bg-white/30"
+      >
+        {darkMode ? 'Light Mode' : 'Dark Mode'}
+      </button>
       <motion.div style={{ y }} ref={ref} className="w-full max-w-md p-4">
         <ChatWidget />
       </motion.div>

--- a/chat-widget/src/components/ChatBubble.tsx
+++ b/chat-widget/src/components/ChatBubble.tsx
@@ -15,8 +15,10 @@ export default function ChatBubble({ message }: Props) {
       className={`my-2 flex ${isUser ? 'justify-end' : 'justify-start'}`}
     >
       <div
-        className={`max-w-[70%] rounded-xl px-4 py-2 text-sm backdrop-blur-xs bg-white/10 text-white shadow-md ${
-          isUser ? 'bg-gradient-to-br from-primary-gradient-start to-primary-gradient-end text-gray-900' : 'bg-white/5'
+        className={`max-w-[70%] rounded-xl px-4 py-2 text-sm backdrop-blur-xs shadow-md ${
+          isUser
+            ? 'bg-gradient-to-br from-primary-gradient-start to-primary-gradient-end text-gray-900 dark:text-white'
+            : 'bg-white/70 dark:bg-gray-700/50 text-gray-900 dark:text-white'
         }`}
       >
         {message.content}

--- a/chat-widget/src/components/ChatWidget.tsx
+++ b/chat-widget/src/components/ChatWidget.tsx
@@ -22,7 +22,7 @@ export default function ChatWidget() {
 
   return (
     <motion.div
-      className="flex flex-col h-full w-full bg-white/10 backdrop-blur-md rounded-xl shadow-xl p-4 text-white"
+      className="flex flex-col h-full w-full bg-white/30 dark:bg-gray-800/50 backdrop-blur-md rounded-2xl shadow-2xl p-4 text-gray-900 dark:text-white"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
@@ -37,11 +37,11 @@ export default function ChatWidget() {
           ref={inputRef}
           type="text"
           placeholder="Type your message..."
-          className="flex-1 rounded-l-lg bg-white/80 text-gray-900 px-3 py-2 focus:outline-none"
+          className="flex-1 rounded-l-lg bg-white/80 dark:bg-gray-700/50 text-gray-900 dark:text-white px-3 py-2 focus:outline-none"
         />
         <button
           type="submit"
-          className="rounded-r-lg bg-gradient-to-br from-primary-gradient-start to-primary-gradient-end text-gray-900 px-4 py-2 font-medium hover:opacity-90"
+          className="rounded-r-lg bg-gradient-to-br from-primary-gradient-start to-primary-gradient-end text-gray-900 dark:text-white px-4 py-2 font-medium hover:opacity-90"
         >
           Send
         </button>

--- a/chat-widget/tailwind.config.cjs
+++ b/chat-widget/tailwind.config.cjs
@@ -1,18 +1,24 @@
 module.exports = {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}"
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {
-        'primary-gradient-start': '#89f7fe',
-        'primary-gradient-end': '#66a6ff'
+        'primary-gradient-start': '#8f5cff',
+        'primary-gradient-end': '#3b82f6',
+        'dark-gradient-start': '#1f2937',
+        'dark-gradient-end': '#111827',
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
       },
       backdropBlur: {
-        xs: '2px'
-      }
+        xs: '2px',
+      },
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- tweak Tailwind config for new gradient, font and dark mode
- load Inter font in HTML
- add dark mode toggle and gradient background
- polish chat widget and bubbles for a glassmorphic style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'framer-motion' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683fd4bf8a708333ad3cf0a49d076635